### PR TITLE
Change name of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "useful issues",
+  "name": "useful-issues",
   "private": true,
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
I encountered `WARN Invalid name: "useful issues"` when I tried `npm install`. And no package was installed. 

So, how about changing the name?

ref. https://docs.npmjs.com/files/package.json
> Therefore, the name can't contain any non-URL-safe characters.

ただ、よくわからないんだ。

```
mochizuki ~/Developments/useful-issues (develop)
$ npm i
npm WARN Invalid name: "useful issues"
npm WARN useful-issues No description
npm WARN useful-issues No repository field.
npm WARN useful-issues No README data
npm WARN useful-issues No license field.
```